### PR TITLE
fix: typo of API name

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ noBound(...exprs) // like /\B/ for arbitrary character classes
 // The result of these function will match ...
 charSet.difference(a, b) // ... characters that match charSet `a` and don't match charSet `b`
 charSet.intersection(a, b) // ... characters that match both charSet `a` and charSet `b`
-charsSet.complement(a) // ... characters that don't match `a`
+charSet.complement(a) // ... characters that don't match `a`
 charSet.union(...cs) // ... character that match any of the provided charsets
 
 // The lack of non-capturing group API is deliberate. We insert them


### PR DESCRIPTION
BTW: should we use a latest tag in the full API pre-loaded sandbox 
<img width="670" alt="image" src="https://user-images.githubusercontent.com/16515468/205022455-092891b9-b5c2-4c3a-9fe3-c0432ca98847.png">

Cureently it use an old version without `charSet.complement` 